### PR TITLE
[Feature] Incorporate different price types in product list sort

### DIFF
--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -244,10 +244,27 @@ class Standard
 				break;
 
 			case 'price':
+				/** controller/frontend/product/price-types
+				 * Fetch product prices with multiple types
+				 *
+				 * In some cases prices are stored with different types, eg. price per kg.
+				 * This configuration option defines which types are incorporated when sorting
+				 * the product list by price.
+				 *
+				 * @param array List of price types to be considered for order-by-price request
+				 * @since 2018.10
+				 * @category Developer
+				 */
+				$priceTypes = $context->getConfig()->get( 'controller/frontend/product/price-types', array('default') );
+				
 				$currencyid = $context->getLocale()->getCurrencyId();
 
-				$cmpfunc = $search->createFunction( 'index.price:value', array( $listtype, $currencyid, 'default' ) );
-				$expr[] = $search->compare( '!=', $cmpfunc, null );
+				$priceExpr = array();
+				foreach($priceTypes as $type) {
+					$cmpfunc = $search->createFunction( 'index.price:value', array( $listtype, $currencyid, $type ) );
+					$priceExpr[] = $search->compare( '!=', $cmpfunc, null );
+				}
+				$expr[] = $search->combine( '||', $priceExpr );
 
 				$sortfunc = $search->createFunction( 'sort:index.price:value', array( $listtype, $currencyid, 'default' ) );
 				$sortations[] = $search->sort( $direction, $sortfunc );


### PR DESCRIPTION
Hi all,

the default "sort by price" function filters for prices with type `default`, so that
a) products which have no `default` price are not displayed at all (somethime products without a `default` price _should_ be shown, e.g. "price on request" articles)
b) products are ordered by the lowest `*default*` price, which may be misleading. E.g. we show prices per kg or per m², because the `default` price (price per package) is not comparable due to different package sizes. So we needed these "prices per unit" considered, too.

This is why we added the configuration `controller/frontend/product/price-types`, which holds a list of all price types that should be incorporated. If no configuration is set at all, only `default` prices are used (non-breaking behaviour).

IMO, this feature might be useful for other shops as well, so here is the PR. Let me know what you think.