### PR TITLE
Respect specified list type for product list

### DIFF
--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -100,8 +100,8 @@ class Standard
 			$catIds = $list;
 		}
 
-		$expr = array( $filter->compare( '==', 'index.catalog.id', array_unique( $catIds ) ) );
-		$expr[] = $filter->getConditions();
+		$cmpfunc = $filter->createFunction( 'index.catalog:position', array( $listtype, array_unique( $catIds ) ) );
+		$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
 
 		if( $sort === 'relevance' )
 		{

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -117,6 +117,7 @@ class Standard
 			$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
 		}
 
+		$expr[] = $filter->getConditions();
 		$filter->setConditions( $filter->combine( '&&', $expr ) );
 
 		return $filter;

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -100,9 +100,6 @@ class Standard
 			$catIds = $list;
 		}
 
-		$cmpfunc = $filter->createFunction( 'index.catalog:position', array( $listtype, array_unique( $catIds ) ) );
-		$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
-
 		if( $sort === 'relevance' )
 		{
 			$start = $filter->getSliceStart();
@@ -113,6 +110,11 @@ class Standard
 
 			$sortfunc = $filter->createFunction( 'sort:index.catalog:position', array( $listtype, $catIds, $start, $end ) );
 			$filter->setSortations( [$filter->sort( $direction, $sortfunc ), $filter->sort( '+', 'product.id' )] );
+		}
+		else
+		{
+			$cmpfunc = $filter->createFunction( 'index.catalog:position', array( $listtype, array_unique( $catIds ) ) );
+			$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
 		}
 
 		$filter->setConditions( $filter->combine( '&&', $expr ) );

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -84,7 +84,7 @@ class Standard
 	public function addFilterCategory( \Aimeos\MW\Criteria\Iface $filter, $catId,
 		$level = \Aimeos\MW\Tree\Manager\Base::LEVEL_ONE, $sort = null, $direction = '+', $listtype = 'default' )
 	{
-		$catIds = ( !is_array( $catId ) ? explode( ',', $catId ) : $catId );
+		$catIds = ( !is_array( $catId ) ? array_unique( explode( ',', $catId ) ) : array_unique( $catId ) );
 
 		if( $level != \Aimeos\MW\Tree\Manager\Base::LEVEL_ONE )
 		{
@@ -101,7 +101,7 @@ class Standard
 		}
 
 		$expr = [$filter->getConditions()];
-		$expr[] = $this->filter->compare( '==', 'index.catalog.id', $ids );
+		$expr[] = $filter->compare( '==', 'index.catalog.id', $catIds );
 
 		if( $sort === 'relevance' )
 		{
@@ -116,7 +116,7 @@ class Standard
 		}
 		else
 		{
-			$cmpfunc = $filter->createFunction( 'index.catalog:position', array( $listtype, array_unique( $catIds ) ) );
+			$cmpfunc = $filter->createFunction( 'index.catalog:position', array( $listtype, $catIds ) );
 			$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
 		}
 

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -100,6 +100,8 @@ class Standard
 			$catIds = $list;
 		}
 
+		$expr = [$filter->getConditions()];
+
 		if( $sort === 'relevance' )
 		{
 			$start = $filter->getSliceStart();
@@ -117,7 +119,6 @@ class Standard
 			$expr[] = $filter->compare( '>=', $cmpfunc, 0 );
 		}
 
-		$expr[] = $filter->getConditions();
 		$filter->setConditions( $filter->combine( '&&', $expr ) );
 
 		return $filter;

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -101,6 +101,7 @@ class Standard
 		}
 
 		$expr = [$filter->getConditions()];
+		$expr[] = $this->filter->compare( '==', 'index.catalog.id', $ids );
 
 		if( $sort === 'relevance' )
 		{

--- a/controller/frontend/src/Controller/Frontend/Product/Standard.php
+++ b/controller/frontend/src/Controller/Frontend/Product/Standard.php
@@ -84,7 +84,7 @@ class Standard
 	public function addFilterCategory( \Aimeos\MW\Criteria\Iface $filter, $catId,
 		$level = \Aimeos\MW\Tree\Manager\Base::LEVEL_ONE, $sort = null, $direction = '+', $listtype = 'default' )
 	{
-		$catIds = ( !is_array( $catId ) ? array_unique( explode( ',', $catId ) ) : array_unique( $catId ) );
+		$catIds = array_unique( !is_array( $catId ) ? explode( ',', $catId ) : $catId );
 
 		if( $level != \Aimeos\MW\Tree\Manager\Base::LEVEL_ONE )
 		{

--- a/controller/frontend/tests/Controller/Frontend/Product/StandardTest.php
+++ b/controller/frontend/tests/Controller/Frontend/Product/StandardTest.php
@@ -116,13 +116,19 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$filter = $this->object->addFilterCategory( $filter, $catId, $level );
 
 		$list = $filter->getConditions()->getExpressions();
+		$expr1 = $list[0]->getExpressions();
+		$expr2 = $list[2];
 
-		if( !isset( $list[0] ) || !( $list[0] instanceof \Aimeos\MW\Criteria\Expression\Compare\Iface ) ) {
-			throw new \RuntimeException( 'Wrong expression' );
+		if( !isset( $expr1[0] ) || !( $expr1[0] instanceof \Aimeos\MW\Criteria\Expression\Compare\Iface ) ) {
+			throw new \RuntimeException( 'Wrong expression 1' );
 		}
 
-		$this->assertEquals( 'index.catalog.id', $list[0]->getName() );
-		$this->assertEquals( 3, count( $list[0]->getValue() ) );
+		if( !isset( $expr2 ) || !( $expr2 instanceof \Aimeos\MW\Criteria\Expression\Compare\Iface ) ) {
+			throw new \RuntimeException( 'Wrong expression 2' );
+		}
+
+		$this->assertEquals( 'index.catalog.id', $expr1[0]->getName() );
+		$this->assertEquals( 'index.catalog:position("default",["1","2","3"])', $expr2->getName() );
 		$this->assertEquals( [], $filter->getSortations() );
 	}
 


### PR DESCRIPTION
The function `addFilterCategory()` in `\Aimeos\Controller\Frontend\Product` has the parameter:

> @param string $listtype Type of the product list, e.g. default, promotion, etc.

which currently only works in "Sort by relevance" mode and is ignored with other sort methods. This leads to inconsistent product lists if products have other categories then "default".